### PR TITLE
Update README.md, fix installation script for Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ curl --silent "https://api.github.com/repos/covexo/devspace/releases/latest" | s
 
 ### For Mac
 ```bash
-curl --silent "https://api.github.com/repos/covexo/devspace/releases/latest" | sed -nE 's!.*"(https://github.com[^"]*devspace-darwin-amd64)".*!\1!p' | xargs -n 1 curl -L -o devspace && chmod +x devspace && sudo mv devspace /usr/local/bin
+curl -s -H "Accept: application/json"  "https://api.github.com/repos/covexo/devspace/releases/latest"  | sed -nE 's!.*"(https://github.com[^"]*devspace-darwin-amd64)".*!\1!p' | xargs -n 1 curl -L -o devspace && chmod +x devspace && sudo mv devspace /usr/local/bin
 ```
 
 ## [Quickstart](https://devspace.covexo.com/docs/getting-started/quickstart.html)


### PR DESCRIPTION
Curl needs "Accept: application/json" in request header, else  call 
curl "https://api.github.com/repos/covexo/devspace/releases/latest" fails with following error message 
{
  "message": "Unsupported 'Accept' header: [#<Sinatra::Request::AcceptEntry:0x00007f8e4e2f8878 @entry=\"application/vnd.heroku+json; version=3\", @type=\"application/vnd.heroku+json\", @params={\"version\"=>\"3\"}, @q=1.0>]. Must accept 'application/json'.",
  "documentation_url": "https://developer.github.com/v3/media"
}