### PR TITLE
Impl service flags to add cmd

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -28,12 +28,14 @@ type addSyncCmdFlags struct {
 	ContainerPath string
 	ExcludedPaths string
 	Namespace     string
+	Service       string
 }
 
 type addPortCmdFlags struct {
 	ResourceType  string
 	LabelSelector string
 	Namespace     string
+	Service       string
 }
 
 type addPackageFlags struct {
@@ -119,6 +121,7 @@ func init() {
 	addSyncCmd.Flags().StringVar(&cmd.syncFlags.Namespace, "namespace", "", "Namespace to use")
 	addSyncCmd.Flags().StringVar(&cmd.syncFlags.ContainerPath, "container", "", "Absolute container path")
 	addSyncCmd.Flags().StringVar(&cmd.syncFlags.ExcludedPaths, "exclude", "", "Comma separated list of paths to exclude (e.g. node_modules/,bin,*.exe)")
+	addSyncCmd.Flags().StringVar(&cmd.syncFlags.Service, "service", "", "The kubernetes service")
 
 	addSyncCmd.MarkFlagRequired("local")
 	addSyncCmd.MarkFlagRequired("container")
@@ -142,6 +145,7 @@ func init() {
 	addPortCmd.Flags().StringVar(&cmd.portFlags.ResourceType, "resource-type", "pod", "Selected resource type")
 	addPortCmd.Flags().StringVar(&cmd.portFlags.Namespace, "namespace", "", "Namespace to use")
 	addPortCmd.Flags().StringVar(&cmd.portFlags.LabelSelector, "label-selector", "", "Comma separated key=value label-selector list (e.g. release=test)")
+	addPortCmd.Flags().StringVar(&cmd.portFlags.Service, "service", "", "The kubernetes service")
 
 	addCmd.AddCommand(addPortCmd)
 
@@ -273,7 +277,7 @@ func (cmd *AddCmd) RunAddDeployment(cobraCmd *cobra.Command, args []string) {
 
 // RunAddSync executes the add sync command logic
 func (cmd *AddCmd) RunAddSync(cobraCmd *cobra.Command, args []string) {
-	err := configure.AddSyncPath(cmd.syncFlags.LocalPath, cmd.syncFlags.ContainerPath, cmd.syncFlags.Namespace, cmd.syncFlags.LabelSelector, cmd.syncFlags.ExcludedPaths)
+	err := configure.AddSyncPath(cmd.syncFlags.LocalPath, cmd.syncFlags.ContainerPath, cmd.syncFlags.Namespace, cmd.syncFlags.LabelSelector, cmd.syncFlags.ExcludedPaths, cmd.syncFlags.Service)
 	if err != nil {
 		log.Fatalf("Error adding sync path: %v", err)
 	}
@@ -281,7 +285,7 @@ func (cmd *AddCmd) RunAddSync(cobraCmd *cobra.Command, args []string) {
 
 // RunAddPort executes the add port command logic
 func (cmd *AddCmd) RunAddPort(cobraCmd *cobra.Command, args []string) {
-	err := configure.AddPort(cmd.portFlags.Namespace, cmd.portFlags.LabelSelector, args)
+	err := configure.AddPort(cmd.portFlags.Namespace, cmd.portFlags.LabelSelector, cmd.portFlags.Service, args)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -121,7 +121,7 @@ func init() {
 	addSyncCmd.Flags().StringVar(&cmd.syncFlags.Namespace, "namespace", "", "Namespace to use")
 	addSyncCmd.Flags().StringVar(&cmd.syncFlags.ContainerPath, "container", "", "Absolute container path")
 	addSyncCmd.Flags().StringVar(&cmd.syncFlags.ExcludedPaths, "exclude", "", "Comma separated list of paths to exclude (e.g. node_modules/,bin,*.exe)")
-	addSyncCmd.Flags().StringVar(&cmd.syncFlags.Service, "service", "", "The kubernetes service")
+	addSyncCmd.Flags().StringVar(&cmd.syncFlags.Service, "service", "", "The devspace config service")
 
 	addSyncCmd.MarkFlagRequired("local")
 	addSyncCmd.MarkFlagRequired("container")
@@ -145,7 +145,7 @@ func init() {
 	addPortCmd.Flags().StringVar(&cmd.portFlags.ResourceType, "resource-type", "pod", "Selected resource type")
 	addPortCmd.Flags().StringVar(&cmd.portFlags.Namespace, "namespace", "", "Namespace to use")
 	addPortCmd.Flags().StringVar(&cmd.portFlags.LabelSelector, "label-selector", "", "Comma separated key=value label-selector list (e.g. release=test)")
-	addPortCmd.Flags().StringVar(&cmd.portFlags.Service, "service", "", "The kubernetes service")
+	addPortCmd.Flags().StringVar(&cmd.portFlags.Service, "service", "", "The devspace config service")
 
 	addCmd.AddCommand(addPortCmd)
 

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -231,6 +231,7 @@ func init() {
 	addImageCmd.Flags().StringVar(&cmd.imageFlags.DockerfilePath, "dockerfile", "", "The path of the images' dockerfile")
 	addImageCmd.Flags().StringVar(&cmd.imageFlags.BuildEngine, "buildengine", "", "Specify which engine should build the file. Should match this regex: docker|kaniko")
 
+	addImageCmd.MarkFlagRequired("name")
 	addCmd.AddCommand(addImageCmd)
 
 	addServiceCmd := &cobra.Command{
@@ -293,10 +294,6 @@ func (cmd *AddCmd) RunAddPort(cobraCmd *cobra.Command, args []string) {
 
 // RunAddImage executes the add image command logic
 func (cmd *AddCmd) RunAddImage(cobraCmd *cobra.Command, args []string) {
-	if cmd.imageFlags.Name == "" {
-		log.Fatal(`Missing required parameter "name"`)
-		return
-	}
 
 	err := configure.AddImage(args[0], cmd.imageFlags.Name, cmd.imageFlags.Tag, cmd.imageFlags.ContextPath, cmd.imageFlags.DockerfilePath, cmd.imageFlags.BuildEngine)
 	if err != nil {

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -264,6 +264,8 @@ func (cmd *AddCmd) RunAddPackage(cobraCmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	log.Donef("Successfully added the package")
 }
 
 // RunAddDeployment executes the add deployment command logic
@@ -282,6 +284,8 @@ func (cmd *AddCmd) RunAddSync(cobraCmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatalf("Error adding sync path: %v", err)
 	}
+
+	log.Donef("Successfully added sync between local path %v and container path %v", cmd.syncFlags.LocalPath, cmd.syncFlags.ContainerPath)
 }
 
 // RunAddPort executes the add port command logic
@@ -290,11 +294,12 @@ func (cmd *AddCmd) RunAddPort(cobraCmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	log.Donef("Successfully added port %v", args[0])
 }
 
 // RunAddImage executes the add image command logic
 func (cmd *AddCmd) RunAddImage(cobraCmd *cobra.Command, args []string) {
-
 	err := configure.AddImage(args[0], cmd.imageFlags.Name, cmd.imageFlags.Tag, cmd.imageFlags.ContextPath, cmd.imageFlags.DockerfilePath, cmd.imageFlags.BuildEngine)
 	if err != nil {
 		log.Fatal(err)
@@ -305,7 +310,6 @@ func (cmd *AddCmd) RunAddImage(cobraCmd *cobra.Command, args []string) {
 
 // RunAddService executes the add image command logic
 func (cmd *AddCmd) RunAddService(cobraCmd *cobra.Command, args []string) {
-
 	err := configure.AddService(args[0], cmd.serviceFlags.LabelSelector, cmd.serviceFlags.Namespace)
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/devspace/configure/port.go
+++ b/pkg/devspace/configure/port.go
@@ -16,6 +16,10 @@ func AddPort(namespace, labelSelector, serviceName string, args []string) error 
 	var labelSelectorMap map[string]*string
 	var err error
 
+	if labelSelector != "" && serviceName != "" {
+		return fmt.Errorf("both service and label-selector specified. This is illegal because the label-selector is already specified in the referenced service. Therefore defining both is redundant")
+	}
+
 	if labelSelector == "" {
 		config := configutil.GetConfig()
 
@@ -149,6 +153,12 @@ func insertOrReplacePortMapping(namespace string, labelSelectorMap map[string]*s
 			return
 		}
 	}
+
+	//We set labelSelectorMap to nil since labelSelectorMap is already specified in service. Avoid redundance.
+	if serviceName != "" {
+		labelSelectorMap = nil
+	}
+
 	portMap := append(*config.DevSpace.Ports, &v1.PortForwardingConfig{
 		ResourceType:  nil,
 		LabelSelector: &labelSelectorMap,

--- a/pkg/devspace/configure/port.go
+++ b/pkg/devspace/configure/port.go
@@ -210,7 +210,6 @@ func parsePortMappings(portMappingsString string) ([]*v1.PortMapping, error) {
 }
 
 func getServiceWithName(services []*v1.ServiceConfig, name string) *v1.ServiceConfig {
-
 	for _, service := range services {
 		if *service.Name == name {
 			return service
@@ -218,5 +217,4 @@ func getServiceWithName(services []*v1.ServiceConfig, name string) *v1.ServiceCo
 	}
 
 	return nil
-
 }

--- a/pkg/devspace/configure/sync.go
+++ b/pkg/devspace/configure/sync.go
@@ -22,6 +22,10 @@ func AddSyncPath(localPath, containerPath, namespace, labelSelector, excludedPat
 	var labelSelectorMap map[string]*string
 	var err error
 
+	if labelSelector != "" && serviceName != "" {
+		return fmt.Errorf("both service and label-selector specified. This is illegal because the label-selector is already specified in the referenced service. Therefore defining both is redundant")
+	}
+
 	if labelSelector == "" {
 		config := configutil.GetConfig()
 
@@ -69,6 +73,11 @@ func AddSyncPath(localPath, containerPath, namespace, labelSelector, excludedPat
 
 	if containerPath[0] != '/' {
 		return errors.New("ContainerPath (--container) must start with '/'. Info: There is an issue with MINGW based terminals like git bash")
+	}
+
+	//We set labelSelectorMap to nil since labelSelectorMap is already specified in service. Avoid redundance.
+	if serviceName != "" {
+		labelSelectorMap = nil
 	}
 
 	syncConfig := append(*config.DevSpace.Sync, &v1.SyncConfig{

--- a/pkg/devspace/configure/sync.go
+++ b/pkg/devspace/configure/sync.go
@@ -12,7 +12,7 @@ import (
 )
 
 // AddSyncPath adds a new sync path to the config
-func AddSyncPath(localPath, containerPath, namespace, labelSelector, excludedPathsString string) error {
+func AddSyncPath(localPath, containerPath, namespace, labelSelector, serviceName string, excludedPathsString string) error {
 	config := configutil.GetConfig()
 
 	if config.DevSpace.Sync == nil {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others)  
/kind feature


**What is this pull request for? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)  
It adds a service-flag to the commands "add port" and "add sync".


**Does this pull request has user-facing changes?** (e.g. config changes, new/modified commands, new/modified flags)  
New flags to use

**Does this pull request add new dependencies?**  
no

**What else do we need to know?**  
A bug is solved. If the program compared two maps representing labelSelectors with equal length but different keys, the program ran into a nil pointer. Until now.